### PR TITLE
fix: use dtype instead of deprecated torch_dtype

### DIFF
--- a/train.py
+++ b/train.py
@@ -29,6 +29,14 @@ from model.utils import find_target_linear_names
 from data.dataset import HybridDataset, collate_fn
 from data.data_utils import AverageMeter, ProgressMeter, Summary, dict_to_cuda
 from utils.utils import save_args_to_json, create_log_dir
+from packaging.version import Version
+
+def _dtype_kwargs(dtype):
+    """`dtype` keyword of `from_pretrained` exists since transformers 4.56 (PR #39782);
+    older versions use `torch_dtype`."""
+    if Version(transformers.__version__) >= Version("4.56"):
+        return {"dtype": dtype}
+    return {"torch_dtype": dtype}
 
 def env_init(distributed=True):
     print("Init Env for Distributed Training")
@@ -330,7 +338,7 @@ def main(args):
 
         model = ShowUIForConditionalGeneration.from_pretrained(
             model_url,
-            torch_dtype=torch_dtype,
+            **_dtype_kwargs(torch_dtype),
             low_cpu_mem_usage=True,
             _attn_implementation=args.attn_imple,
             quantization_config=bnb_config,
@@ -343,7 +351,7 @@ def main(args):
 
         model = Qwen2VLForConditionalGeneration.from_pretrained(
             model_url,
-            torch_dtype=torch_dtype,
+            **_dtype_kwargs(torch_dtype),
             low_cpu_mem_usage=True,
             _attn_implementation=args.attn_imple,
             quantization_config=bnb_config,


### PR DESCRIPTION
## Summary

`config.torch_dtype` and the `torch_dtype` keyword argument were deprecated in transformers 4.56 (PR #39782) and replaced by `dtype`. This PR updates the two `from_pretrained` calls in `train.py` (`ShowUIForConditionalGeneration` line 331 and `Qwen2VLForConditionalGeneration` line 344) to select the keyword from the installed transformers version using `packaging.version`, so transformers < 4.56 keeps working. All other arguments (`_attn_implementation`, `quantization_config`, `device_map`, `lm_skip_layer`, `lm_skip_ratio`, ...) are unchanged.

## Changes

- `train.py`: add a `_dtype_kwargs` helper that returns `{"dtype": ...}` on transformers >= 4.56 and `{"torch_dtype": ...}` otherwise; both `from_pretrained` calls pass it as `**_dtype_kwargs(torch_dtype)`.

## Test

- The modified file compiles (`python -m py_compile`).
- On transformers >= 4.56 the calls use `dtype` and emit no deprecation warning; on older versions they pass `torch_dtype` unchanged.

Fixes #99